### PR TITLE
feat(shoal): Added support for evicting data from memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,16 +521,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
+name = "deepsize2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+checksum = "86b5184084af9beed35eecbf4c36baf6e26b9dc47b61b74e02f930c72a58e71b"
 dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
+ "deepsize_derive2",
+]
+
+[[package]]
+name = "deepsize_derive2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f8817865cacf3b93b943ca06b0fc5fd8e99eabfdb7ea5d296efcbc4afc4f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -605,6 +618,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -827,12 +846,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -842,6 +855,11 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1162,6 +1180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lru"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+dependencies = [
+ "hashbrown 0.16.0",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2035,10 +2081,12 @@ name = "shoal"
 version = "0.1.0"
 dependencies = [
  "csv-async",
+ "deepsize2",
  "futures",
  "glommio",
  "gxhash",
  "kanal",
+ "mimalloc",
  "owo-colors",
  "rkyv 0.8.12",
  "serde",
@@ -2056,12 +2104,13 @@ dependencies = [
  "bytes",
  "clap",
  "config",
- "dashmap",
+ "deepsize2",
  "futures",
  "glommio",
  "gxhash",
  "intmap",
  "kanal",
+ "lru",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,11 @@ members = [
     "shoal-derive",
 ]
 
-[profile.release]
-debug = true
+[workspace.dependencies]
+rkyv = { version = "0.8.10", features = ["uuid-1"] }
+gxhash = "2.2"
+uuid = { version = "1", features = ["v4"] }
+glommio = { version = "0.9" }
+tokio = { version = "1", features = ["full"] }
+kanal = "0.1.0-pre8"
+mimalloc = { version = "0.1.0"}

--- a/shoal-core/Cargo.toml
+++ b/shoal-core/Cargo.toml
@@ -16,19 +16,20 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 config = "0.13" 
 gxhash = "2.2"
-rkyv = { version = "0.8.10", features = ["uuid-1"] }
+rkyv = { workspace = true }
 rkyv-with = "0.1"
-glommio = { version = "0.9", optional = true }
+glommio = { workspace = true, optional = true }
 bytes = "1.5"
 intmap = "2"
 futures = "0.3"
-kanal = "0.1.0-pre8"
-tokio = { version = "1", features = ["full"] }
-uuid = { version = "1", features = ["v4"] }
-dashmap = "5.5"
+kanal = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
 papaya = "0.2"
-byte-unit = "5.1"
+byte-unit = { version = "5.1", features = ["serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+deepsize2 = "0.1"
+lru = "0.16"
 
 # tracing dependencies
 opentelemetry = "0.28"

--- a/shoal-core/src/lib.rs
+++ b/shoal-core/src/lib.rs
@@ -5,7 +5,9 @@ pub mod server;
 pub mod shared;
 
 pub use client::FromShoal;
+pub use lru;
 pub use rkyv;
 pub use server::tables;
 pub use server::tables::storage;
 pub use server::ShoalPool;
+pub use xxhash_rust;

--- a/shoal-core/src/server.rs
+++ b/shoal-core/src/server.rs
@@ -111,7 +111,7 @@ where
         // setup tracing/telemetry
         trace::setup(&conf);
         // get the total number of cpus that we have
-        let cpus = conf.compute.cpus()?;
+        let cpus = conf.resources.cpus()?;
         // our mesh should always be one larger then the number of cores
         // so that the coordinator can also join the mesh
         let mesh_size = cpus.len() + 1;

--- a/shoal-core/src/server/conf.rs
+++ b/shoal-core/src/server/conf.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use byte_unit::Byte;
 use config::{Config, ConfigError};
 use glommio::CpuSet;
 use serde::{Deserialize, Serialize};
@@ -11,16 +12,16 @@ use super::ServerError;
 // The table specific configs
 pub use crate::server::tables::storage::fs::conf::FileSystemTableConf;
 
-/// The compute settings to use
+/// The resource settings to use
 #[derive(Serialize, Deserialize, Default, Clone)]
-pub struct Compute {
+pub struct Resources {
     /// Configure the number of cores to use, default to all
-    cores: Option<usize>,
+    pub cores: Option<usize>,
     /// The max amount of memory to use
-    memory: Option<usize>,
+    pub memory: Byte,
 }
 
-impl Compute {
+impl Resources {
     /// Get the cpuset to run shoal on
     pub fn cpus(&self) -> Result<CpuSet, ServerError> {
         // get all online cpus
@@ -148,7 +149,7 @@ pub struct Tracing {
 pub struct Conf {
     /// The compute settings to use
     #[serde(default)]
-    pub compute: Compute,
+    pub resources: Resources,
     /// The networking settings to use
     #[serde(default)]
     pub networking: Networking,

--- a/shoal-core/src/server/coordinator.rs
+++ b/shoal-core/src/server/coordinator.rs
@@ -82,7 +82,7 @@ where
         };
         // spawn our mesh listeners
         coordinator.spawn_mesh_listeners(&kanal_tx).await;
-        // spawmn our client litener
+        // spawn our client litener
         coordinator.spawn_client_listener(&kanal_tx)?;
         // start handling messages
         coordinator.start_handling().await;
@@ -94,7 +94,7 @@ where
         // wait for the full number of listeners to have connected
         loop {
             // check how many of our shards have connected
-            if self.mesh_rx.nr_producers() < self.conf.compute.cpus().unwrap().len() - 1 {
+            if self.mesh_rx.nr_producers() < self.conf.resources.cpus().unwrap().len() - 1 {
                 // not all of our shards are ready so sleep
                 glommio::timer::sleep(Duration::from_millis(100)).await;
                 // restart our loop

--- a/shoal-core/src/server/messages.rs
+++ b/shoal-core/src/server/messages.rs
@@ -97,6 +97,12 @@ pub enum ShardMsg<D: ShoalDatabase> {
     },
     /// A partition loaded from disk
     Partition(LoadedPartitionKinds<D>),
+    /// Mark some partitions as evictable
+    MarkEvictable {
+        generation: u64,
+        table: D::TableNames,
+        partitions: Vec<u64>,
+    },
     /// Tell this shard to shutdown
     Shutdown,
 }

--- a/shoal-core/src/server/tables/storage/fs/map.rs
+++ b/shoal-core/src/server/tables/storage/fs/map.rs
@@ -457,10 +457,12 @@ impl ArchiveMap {
     ///
     /// * `id` - The id of the archive we are removing
     pub async fn remove_archive(&self, id: &Uuid) -> Result<(), ServerError> {
-        // insert or update this partitions entry to disk
+        // remove this archive from our loaded archive file handle map
         if let Some(removed) = self.loaded_archives.borrow_mut().remove(id) {
             removed.close().await?;
         }
+        // remove this archive from our map of all archives
+        self.all_archives.borrow_mut().remove(id);
         Ok(())
     }
 

--- a/shoal-core/src/shared/traits/unsorted.rs
+++ b/shoal-core/src/shared/traits/unsorted.rs
@@ -1,11 +1,13 @@
 //! The traits for a basic unsorted table where each partition contains a
 //! single row
 
+use deepsize2::DeepSizeOf;
+
 use super::{PartitionKeySupport, RkyvSupport};
 use crate::shared::queries::UnsortedUpdate;
 
 pub trait ShoalUnsortedTable:
-    std::fmt::Debug + Clone + RkyvSupport + PartitionKeySupport + Sized
+    std::fmt::Debug + Clone + RkyvSupport + PartitionKeySupport + Sized + DeepSizeOf
 {
     /// The updates that can be applied to this table
     type Update: RkyvSupport + std::fmt::Debug + Clone;

--- a/shoal/Cargo.toml
+++ b/shoal/Cargo.toml
@@ -13,16 +13,18 @@ path = "src/lib.rs"
 [dependencies]
 shoal-core = { version = "0.1.0", path = "../shoal-core" }
 shoal-derive = { version = "0.1.0", path = "../shoal-derive" }
-rkyv = { version = "0.8.10", features = ["uuid-1"] }
-gxhash = "2.2"
-uuid = { version = "1", features = ["v4"] }
-glommio = { version = "0.9" }
-tokio = { version = "1", features = ["full"] }
+rkyv = { workspace = true }
+gxhash = { workspace = true }
+uuid = { workspace = true }
+glommio = { workspace = true }
+tokio = { workspace = true }
 owo-colors = "4.1"
-kanal = "0.1.0-pre8"
+kanal = { workspace = true }
+mimalloc = { workspace = true }
 
 [dev-dependencies]
 csv-async = { version = "1.3", features = ["tokio", "with_serde"] }
 serde = "1.0.219"
 futures = "0.3"
 kanal = "0.1.0-pre8"
+deepsize2 = "0.1"

--- a/shoal/src/bencher.rs
+++ b/shoal/src/bencher.rs
@@ -250,10 +250,15 @@ impl Bencher {
         }
         // calculate the index for the item in the 99th percentile
         let index = (self.instance_times.len() as f64 * percentile).ceil() as usize;
+        // if our index is larger then the number of times then just use the max
+        let index = std::cmp::min(index, self.instance_times.len() - 1);
         // get the time at the target percentile
         self.instance_times
             .get(index)
-            .expect("Failed to get p{percentile}")
+            .expect(&format!(
+                "Failed to get p{percentile} at {index}/{}",
+                self.instance_times.len()
+            ))
             .clone()
     }
 


### PR DESCRIPTION
This allows shoal to handle more data then can fit in memory without OOMing. The soft limit for much ram to use per shard can be configured in the shoal.yml config.

Closes #19